### PR TITLE
Use Java 17 toolchain

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,11 +12,11 @@ apply plugin: 'kotlin-android'
           viewBinding true
       }
       compileOptions {
-          sourceCompatibility JavaVersion.VERSION_21
-          targetCompatibility JavaVersion.VERSION_21
+          sourceCompatibility JavaVersion.VERSION_17
+          targetCompatibility JavaVersion.VERSION_17
       }
       kotlinOptions {
-          jvmTarget = "21"
+          jvmTarget = "17"
       }
       defaultConfig {
           applicationId "com.ninenox.kotlinmultilanguage"

--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ allprojects {
 subprojects {
     plugins.withId('org.jetbrains.kotlin.android') {
         kotlin {
-            jvmToolchain(21)
+            jvmToolchain(17)
         }
     }
 }

--- a/kotlinlocalemanager/build.gradle
+++ b/kotlinlocalemanager/build.gradle
@@ -17,11 +17,11 @@ version = '1.0.1'
           viewBinding true
       }
       compileOptions {
-          sourceCompatibility JavaVersion.VERSION_21
-          targetCompatibility JavaVersion.VERSION_21
+          sourceCompatibility JavaVersion.VERSION_17
+          targetCompatibility JavaVersion.VERSION_17
       }
       kotlinOptions {
-          jvmTarget = "21"
+          jvmTarget = "17"
       }
 
       defaultConfig {


### PR DESCRIPTION
## Summary
- Switch Kotlin toolchain to Java 17 for all modules
- Align compile and target compatibility with Java 17

## Testing
- `./gradlew tasks` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68b3bd9c3e30832b975722233336d90f