### PR TITLE
Fix unresolved references by using view binding for language buttons

### DIFF
--- a/app/src/main/java/com/ninenox/kotlinmultilanguage/MainActivity.kt
+++ b/app/src/main/java/com/ninenox/kotlinmultilanguage/MainActivity.kt
@@ -19,13 +19,11 @@ class MainActivity : AppCompatActivityBase() {
     }
 
     private fun initView() {
-        change_language_th_button.setOnClickListener {
+        binding.changeLanguageThButton.setOnClickListener {
             setNewLocale(LANGUAGE_THAI)
         }
-        change_language_en_button.setOnClickListener {
+        binding.changeLanguageEnButton.setOnClickListener {
             setNewLocale(LANGUAGE_ENGLISH)
-
-
         }
     }
 }


### PR DESCRIPTION
## Summary
- Use `ActivityMainBinding` to access the Thai and English language buttons instead of synthetic view references.

## Testing
- `./gradlew build` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68b3cf155cf4832b9da4d99892d9b600